### PR TITLE
firefox: change default shortcut to "Ctrl+Alt+C"

### DIFF
--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -11,8 +11,8 @@
   "commands": {
     "_execute_sidebar_action": {
       "suggested_key": {
-        "mac": "Command+Alt+Y",
-        "default": "Ctrl+Alt+Y"
+        "mac": "Command+Alt+C",
+        "default": "Ctrl+Alt+C"
       },
       "description": "Toggle sidebar action."
     }


### PR DESCRIPTION
* I realized the advantage of Firefox using "Ctrl+Alt+X" as default chat shortcut is it the 3 keys are in close proximity. That makes it easy to trigger with a single hand.

* Our previous shortcut "Ctrl+Alt+Y", with this perspective, is not similar to the Firefox chat sidebar and is also not good.

* Changed to "Ctrl+Alt+C", which as far as I tested is not used in Firefox. Also "C" can be easily associated with "Chat", which the sidebar is largely for.

* I figure since v1.2 is only released 2 days ago, the new keyboard shortcut is not in users' muscle memory yet (if that's a concern). It is still a good time to change.